### PR TITLE
chore: establish reviewed release path

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,47 @@
+name: pr-governance
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-description:
+    name: validate-pr-description
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body structure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request?.body || '').trim();
+            const missing = [];
+
+            const requiredSections = [
+              '## Summary',
+              '## Linked issue',
+              '## Spec artifacts',
+              '## Verification',
+              '## Deployment'
+            ];
+
+            for (const section of requiredSections) {
+              if (!body.includes(section)) missing.push(`missing section: ${section}`);
+            }
+
+            const issueLinked = /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+/i.test(body) || /#\d+/.test(body);
+            if (!issueLinked) {
+              missing.push('missing linked issue reference such as "Closes #123"');
+            }
+
+            if (missing.length > 0) {
+              core.setFailed(`PR governance check failed: ${missing.join('; ')}`);
+            }
+
+      - name: Validate PR title style
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = (context.payload.pull_request?.title || '').trim();
+            if (title.length < 8) {
+              core.setFailed('PR title is too short to be reviewable.');
+            }


### PR DESCRIPTION
## Summary
Establish the reviewed GitHub release path for production deployment governance.

## Linked issue
Closes #1

## Spec artifacts
070 production deployment review artifacts already prepared in the repo.

## Verification
Connected local repo to GitHub
Pushed main
Created release/070-reviewed-path
Opened PR into main

## Deployment
No production deploy in this PR
Deployment remains gated until approval and required checks are satisfied
